### PR TITLE
Fixed bugs in Discard and Rollback tools

### DIFF
--- a/asset_manager/utilities.py
+++ b/asset_manager/utilities.py
@@ -176,6 +176,12 @@ def isVersionedFolder(dirPath):
 	else:
 		return False
 
+def isCheckedOutCopyFolder(dirPath):
+	if os.path.exists(os.path.join(dirPath, ".checkoutInfo")):
+		return True
+	else:
+		return False
+
 def isInstalled(dirPath):
 	return bool(glob.glob(os.path.join(dirPath, 'stable', '*stable*')))
 

--- a/maya-tools/shelf/scripts/maya_discard.py
+++ b/maya-tools/shelf/scripts/maya_discard.py
@@ -20,9 +20,19 @@ def discard(filePath=cmds.file(q=True, sceneName=True)):
         print filePath
         dlgResult = showWarningDialog()
         if dlgResult == 'Yes':
-                toDiscard = os.path.dirname(filePath) # get discard directory before opening new file
-                cmds.file(force=True, new=True) #open new file
-                amu.discard(toDiscard) # discard changes
+                # get discard directory before opening new file
+                toDiscard = os.path.join(amu.getUserCheckoutDir(), os.path.basename(os.path.dirname(filePath)))
+                if(amu.isCheckedOutCopyFolder(toDiscard)): 
+                        cmds.file(force=True, new=True) #open new file
+                        amu.discard(toDiscard) # discard changes
+                else:
+                        cmds.confirmDialog(  title         = 'Invalid Command'
+                                           , message       = 'This is not a checked out file. There is nothing to discard.'
+                                           , button        = ['Ok']
+                                           , defaultButton = 'Ok'
+                                           , cancelButton  = 'Ok'
+                                           , dismissString = 'Ok')
+
         elif dlgResult == 'Brent':
                 brent.go()
         else:

--- a/maya-tools/shelf/scripts/maya_rollback.py
+++ b/maya-tools/shelf/scripts/maya_rollback.py
@@ -75,7 +75,7 @@ class RollbackDialog(QDialog):
         self.selection_list.sortItems(0)
 
     def refresh(self):
-        filePath = os.path.split(ORIGINAL_FILE_NAME)[0]
+        filePath = os.path.join(amu.getUserCheckoutDir(), os.path.basename(os.path.dirname(ORIGINAL_FILE_NAME)))
         checkInDest = amu.getCheckinDest(filePath)
         versionFolders = os.path.join(checkInDest, "src")
         selections = glob.glob(os.path.join(versionFolders, '*'))
@@ -94,7 +94,7 @@ class RollbackDialog(QDialog):
         dialogResult = self.showWarningDialog()
         if dialogResult == 'Yes':
             version = str(self.current_item.text())[1:]
-            dirPath = os.path.split(ORIGINAL_FILE_NAME)[0]
+            dirPath = os.path.join(amu.getUserCheckoutDir(), os.path.basename(os.path.dirname(ORIGINAL_FILE_NAME)))
             print dirPath
             cmd.file(force=True, new=True)
             amu.setVersion(dirPath, int(version))
@@ -125,7 +125,7 @@ class RollbackDialog(QDialog):
                                    , dismissString = 'Ok')
 
     def open_version(self):
-        filePath = os.path.split(ORIGINAL_FILE_NAME)[0]
+        filePath = os.path.join(amu.getUserCheckoutDir(), os.path.basename(os.path.dirname(ORIGINAL_FILE_NAME)))
         checkInDest = amu.getCheckinDest(filePath)
         v = str(self.current_item.text())
         checkinPath = os.path.join(checkInDest, "src", v)
@@ -141,6 +141,14 @@ def go():
     dialog.show()
     
 if __name__ == '__main__':
-    if ORIGINAL_FILE_NAME != '':
+    filePath = os.path.join(amu.getUserCheckoutDir(), os.path.basename(os.path.dirname(ORIGINAL_FILE_NAME)))
+    if(amu.isCheckedOutCopyFolder(filePath)):
         cmd.file(save=True, force=True)
         go()
+    else:
+        cmd.confirmDialog(  title         = 'Invalid Command'
+                           , message       = 'This is not a checked out file. There is nothing to rollback.'
+                           , button        = ['Ok']
+                           , defaultButton = 'Ok'
+                           , cancelButton  = 'Ok'
+                           , dismissString = 'Ok')


### PR DESCRIPTION
Rollback and Discard were sometimes not finding the absolute file path to the .checkoutInfo config file (issue #84). Now they use environment variables instead of maya's file command, which seems to have solved the problem.

Both tools now show an error dialog when they are used on unchecked out files (issue #80)
