### PR TITLE
Discard bug fix

### DIFF
--- a/maya-tools/shelf/scripts/maya_discard.py
+++ b/maya-tools/shelf/scripts/maya_discard.py
@@ -14,7 +14,8 @@ def showWarningDialog():
                                  , cancelButton  = 'No'
                                  , dismissString = 'No')
 
-def discard(filePath=cmds.file(q=True, sceneName=True)):
+def discard():
+        filePath=cmds.file(q=True, sceneName=True)
         if not filePath:
           return
         print filePath


### PR DESCRIPTION
Today during dailies someone mentioned that the discard tool doesn't always unlock the assets. I think the problem is that initializing the filepath parameter in the function definition means that it's only run the first time the function is called. So if someone tries to discard changes to a second asset it's still trying to access the first asset's filepath. Moving the variable initialization into the body of the function should fix that.
