### PR TITLE
Rollback Tool update

### DIFF
--- a/asset_manager/utilities.py
+++ b/asset_manager/utilities.py
@@ -201,6 +201,19 @@ def getVersionedFolderInfo(dirPath):
 		nodeInfo.append("")
 	return nodeInfo
 
+def tempSetVersion(chkInDest, version):
+    """
+    Temporarily sets the 'latest version' as the specified version without deleting later versions
+    Returns the version number that we override
+    @precondition 'chkInDest' is a valid versioned folder
+    """
+    nodeInfo = ConfigParser()
+    nodeInfo.read(os.path.join(chkInDest, ".nodeInfo"))
+    latestVersion = nodeInfo.get("Versioning", "latestversion")
+    nodeInfo.set("Versioning", "latestversion", str(version))
+    _writeConfigFile(os.path.join(chkInDest, ".nodeInfo"), nodeInfo)
+    return latestVersion
+
 def setVersion(dirPath, version):	
     """
     Sets the 'latest version' as the specified version and deletes later versions

--- a/maya-tools/shelf/scripts/maya_rollback.py
+++ b/maya-tools/shelf/scripts/maya_rollback.py
@@ -33,6 +33,7 @@ class RollbackDialog(QDialog):
 
         #Create Select and Cancel buttons
         self.open_button = QPushButton('Open Version')
+        self.checkout_button = QPushButton('Checkout Version')
         self.select_button = QPushButton('Rollback')
         self.cancel_button = QPushButton('Cancel')
 
@@ -41,6 +42,7 @@ class RollbackDialog(QDialog):
         button_layout.setSpacing(2)
         button_layout.addStretch()
         button_layout.addWidget(self.open_button)
+        button_layout.addWidget(self.checkout_button)
         button_layout.addWidget(self.select_button)
         button_layout.addWidget(self.cancel_button)
 
@@ -61,6 +63,7 @@ class RollbackDialog(QDialog):
             
         #Connect the buttons
         self.connect(self.open_button, SIGNAL('clicked()'), self.open_version)
+        self.connect(self.checkout_button, SIGNAL('clicked()'), self.checkout_version)
         self.connect(self.select_button, SIGNAL('clicked()'), self.rollback)
         self.connect(self.cancel_button, SIGNAL('clicked()'), self.close_dialog)
 
@@ -125,6 +128,14 @@ class RollbackDialog(QDialog):
                                    , cancelButton  = 'Ok'
                                    , dismissString = 'Ok')
 
+    def verify_checkout_dialog(self):
+        return cmd.confirmDialog(  title           = 'Verify Checkout'
+                                   , message       = 'You are about to checkout an older version of this asset. Once you check it in, it will be saved as the most recent version. Is this what you want?'
+                                   , button        = ['Yes', 'No']
+                                   , defaultButton = 'No'
+                                   , cancelButton  = 'No'
+                                   , dismissString = 'No')
+
     def open_version(self):
         filePath = os.path.join(amu.getUserCheckoutDir(), os.path.basename(os.path.dirname(self.ORIGINAL_FILE_NAME)))
         checkInDest = amu.getCheckinDest(filePath)
@@ -136,6 +147,44 @@ class RollbackDialog(QDialog):
             cmd.file(checkinName, force=True, open=True)
         else:
             self.show_no_file_dialog()
+
+    def checkout_version(self):
+        dialogResult = self.verify_checkout_dialog()
+        if(dialogResult == 'Yes'):
+            #checkout
+            version = str(self.current_item.text())[1:]
+            filePath = os.path.join(amu.getUserCheckoutDir(), os.path.basename(os.path.dirname(self.ORIGINAL_FILE_NAME)))
+            toCheckout = amu.getCheckinDest(filePath)
+            
+            latestVersion = amu.tempSetVersion(toCheckout, version)
+            amu.discard(filePath)
+            #PROBLEMS: file is already locked by this user
+            #               discard changes?
+            #          amu.checkout will only checkout the latest version
+            #               write tempSetVersion method in utilities so checkout will open the desired version ?
+            try:
+                destpath = amu.checkout(toCheckout, True)
+            except Exception as e:
+                if not amu.checkedOutByMe(toCheckout):
+                    cmd.confirmDialog(  title          = 'Can Not Checkout'
+                                   , message       = str(e)
+                                   , button        = ['Ok']
+                                   , defaultButton = 'Ok'
+                                   , cancelButton  = 'Ok'
+                                   , dismissString = 'Ok')
+                    return
+                else:
+                    destpath = amu.getCheckoutDest(toCheckout)
+
+            toOpen = os.path.join(destpath, self.get_filename(toCheckout)+'.mb')
+            self.ORIGINAL_FILE_NAME = toOpen
+            amu.tempSetVersion(toCheckout, latestVersion)
+            if not os.path.exists(toOpen):
+                # create new file
+                cmd.file(force=True, new=True)
+                cmd.file(rename=toOpen)
+                cmd.file(save=True, force=True)
+            self.close_dialog()
 
 def go():
     currentFile = cmd.file(query=True, sceneName=True)

--- a/maya-tools/shelf/scripts/maya_rollback.py
+++ b/maya-tools/shelf/scripts/maya_rollback.py
@@ -158,10 +158,6 @@ class RollbackDialog(QDialog):
             
             latestVersion = amu.tempSetVersion(toCheckout, version)
             amu.discard(filePath)
-            #PROBLEMS: file is already locked by this user
-            #               discard changes?
-            #          amu.checkout will only checkout the latest version
-            #               write tempSetVersion method in utilities so checkout will open the desired version ?
             try:
                 destpath = amu.checkout(toCheckout, True)
             except Exception as e:


### PR DESCRIPTION
The rollback tool now has a 'checkout version' button which allows you to checkout an earlier version. It discards the current file you have checked out and rechecks out the older version that was selected. 
