### PR TITLE
General improvements to launch scripts

### DIFF
--- a/asset_manager/__init__.py
+++ b/asset_manager/__init__.py
@@ -1,0 +1,6 @@
+__all__ = (
+    "utilities.py",
+    "controller.py",
+    "installHoudiniFile.py",
+    "installMayaFile.py",
+)

--- a/project_env.sh
+++ b/project_env.sh
@@ -12,12 +12,18 @@
 # Project specific environment variables
 ###############################################################################
 
-# The name of the project (ie: owned)
-export PROJECT_NAME=owned
-
-# Root directory for the projcet (ie: /groups/owned)
+# Root directory for the project (eg: /groups/owned)
 # This directory should be created manually.
-export JOB=/groups/${PROJECT_NAME}
+# If JOB is not already set, then set it with a hardcoded default.
+# Also, set PROJECT_NAME based on JOB.
+if [ -z "$JOB" ]
+then
+    # The name of the project (eg: owned)
+    export PROJECT_NAME=owned
+    export JOB=/groups/${PROJECT_NAME}
+else
+    export PROJECT_NAME=`basename $JOB`
+fi
 
 # Tools/scripts directory. This project_env.sh script should be placed here.
 # along with the other tools and scripts.

--- a/project_houdini.sh
+++ b/project_houdini.sh
@@ -9,7 +9,11 @@ source ./houdini_setup
 cd -
 
 # source project environment
-source ./project_env.sh
+DIR=`dirname $0`
+source ${DIR}/project_env.sh
+
+# Change directories so $HIP is not in the tools folder
+cd ${JOB}/tmp
 
 echo "Starting Houdini..."
 houdinifx

--- a/project_maya.sh
+++ b/project_maya.sh
@@ -9,6 +9,9 @@ source ${DIR}/project_env.sh
 
 export CURRENT_PROG='Maya'
 
+# Change directories so current directory is not in the tools folder
+cd ${JOB}/tmp
+
 echo "Starting Maya..."
 maya -script ${MAYA_SHELF_DIR}/byu_shelf.mel &
 

--- a/project_nuke.sh
+++ b/project_nuke.sh
@@ -9,6 +9,9 @@ source ${DIR}/project_env.sh
 
 export CURRENT_PROG='Nuke'
 
+# Change directories so current directory is not in the tools folder
+cd ${JOB}/tmp
+
 echo "Starting Nuke..."
 /usr/local/Nuke6.3v9/Nuke6.3 -b --nukex
 


### PR DESCRIPTION
Now project_env.sh will only define $JOB if it is not already defined.
Also, all the application launch scripts change directories to
$JOB/tmp so that the tools folder doesn't get filled with junk (
this has been happening a lot lately Houdini defaults to using $HIP
to pre-pend a lot of things).

Lastly, put an **init**.py file into the asset_manager directory.
The asset_manager folder will eventually be moved under python2.6libs
and with the **init**.py file it will be treated like a module. This
should help organize things. I will get to this when I have enough time
to make sure that moving the directory won't break anything.
