### PR TITLE
Another fix for node info tool

### DIFF
--- a/python2.6libs/hou_asset_mgr.py
+++ b/python2.6libs/hou_asset_mgr.py
@@ -742,9 +742,9 @@ def getNodeInfo(node):
         filename = os.path.basename(libraryPath)
         nodeInfo = getFileInfo(filename)
         message = ''
-        logname, realname = amu.lockedBy(nodeInfo[3].encode('utf-8'))
         if nodeInfo[2]:
+            logname, realname = amu.lockedBy(nodeInfo[3].encode('utf-8'))
             message = 'Checked out by '+realname+' ('+logname+')'
         else:
-            message = 'Not checked out. Last checked in by '+realname+' ('+logname+')'
+            message = 'Not checked out.'
         ui.infoWindow(message, wtitle='Node Info')


### PR DESCRIPTION
Now the tool does not expect to get a valid lockedBy username from the otl database when the asset is not checked out. (When something is checked in the empty string is inserted into the lockedBy column of the table)
