### PR TITLE
If a texture cannot be overwritten, the exception is caught

### DIFF
--- a/python2.6libs/hou_asset_mgr.py
+++ b/python2.6libs/hou_asset_mgr.py
@@ -756,8 +756,12 @@ def newTexture():
      
                 newfilepath = os.path.join(assetImageDir,newTextureName)
 
-                #shutil.copy(finalTexture,newfilepath)
-                fileutil.move(finalTexture, newfilepath)  
+                try:
+                    #shutil.copy(finalTexture,newfilepath)
+                    fileutil.move(finalTexture, newfilepath)  
+                except Exception as e:
+                    ui.infoWindow('Failed to move texture. The following error occured:\n' + str(e))
+                    os.remove(finalTexture)
 
                 if convertedTexture != userTextureMap:
                     os.remove(convertedTexture)


### PR DESCRIPTION
Proper cleanup is also done now (i.e. old files are deleted).
