### PR TITLE
Changing locking mechanism for check in/out

### DIFF
--- a/python2.6libs/hou_asset_mgr.py
+++ b/python2.6libs/hou_asset_mgr.py
@@ -197,7 +197,7 @@ def _lockAssetNew(node, lockit):
         opts.setLockContents(True)
         ndef.setOptions(opts)
 
-lockAsset = _lockAssetOriginal
+lockAsset = _lockAssetNew
 
 def get_filename(parentdir):
     return os.path.basename(os.path.dirname(parentdir))+'_'+os.path.basename(parentdir)


### PR DESCRIPTION
Now assets will be locked with all sub nodes editable. This is
different from before when the assets weren't locked at all once
they were checked in.
