### PR TITLE
Force all library definitions to refresh with refresh tool

### DIFF
--- a/python2.6libs/hou_asset_mgr.py
+++ b/python2.6libs/hou_asset_mgr.py
@@ -687,6 +687,7 @@ def refresh(node = None):
     Everything else is probably either light linking data, or something else 
     that should always have a local override."""
     updateDB()
+    hou.hscript("otrefresh -r") # Refresh all definitions first
     
     if node == None or hasattr(node, "__len__"):
         ui.infoWindow("Select EXACTLY one node.")


### PR DESCRIPTION
This is to make sure the user is getting the latest possible updates when they use this tool.
